### PR TITLE
fix: urljoin api url wrong while use API_ROOT in CookieCloud

### DIFF
--- a/PyCookieCloud/PyCookieCloud.py
+++ b/PyCookieCloud/PyCookieCloud.py
@@ -37,7 +37,7 @@ class PyCookieCloud:
         :return: The encrypted data if the connection is successful, None otherwise.
         """
         if self.check_connection():
-            cookie_cloud_request = requests.get(urljoin(self.url, '/get/' + self.uuid))
+            cookie_cloud_request = requests.get(urljoin(self.url, 'get/' + self.uuid))
             if cookie_cloud_request.status_code == 200:
                 cookie_cloud_response = cookie_cloud_request.json()
                 encrypted_data = cookie_cloud_response["encrypted"]


### PR DESCRIPTION
Some people are willing to [set `API_ROOT` environment variable in CookieCloud](https://github.com/easychen/CookieCloud#%E6%8C%87%E5%AE%9Aapi%E7%9B%AE%E5%BD%95%E5%8F%AF%E9%80%89%E6%AD%A5%E9%AA%A4%E5%8F%AF%E8%B7%B3%E8%BF%87) to protect their server.
This was when [`urljoin` behaves pretty weird](https://stackoverflow.com/questions/10893374/python-confusions-with-urljoin):

```Python
from urllib.parse import urljoin


def main() -> None:
    urls: list = [
        "https://api.cookiecloud.com",
        "https://api.cookiecloud.com/",
        "https://api.cookiecloud.com/api_root",
        "https://api.cookiecloud.com/api_root/",
    ]
    paths: list = ["get/user_key", "/get/user_key"]
    for url in urls:
        for path in paths:
            print(f">>> urljoin('{url}', '{path}')\n'{urljoin(url, path)}'\n")


if __name__ == "__main__":
    main()
```

```
>>> urljoin('https://api.cookiecloud.com', 'get/user_key')
'https://api.cookiecloud.com/get/user_key'

>>> urljoin('https://api.cookiecloud.com', '/get/user_key')
'https://api.cookiecloud.com/get/user_key'

>>> urljoin('https://api.cookiecloud.com/', 'get/user_key')
'https://api.cookiecloud.com/get/user_key'

>>> urljoin('https://api.cookiecloud.com/', '/get/user_key')
'https://api.cookiecloud.com/get/user_key'

>>> urljoin('https://api.cookiecloud.com/api_root', 'get/user_key')
'https://api.cookiecloud.com/get/user_key'

>>> urljoin('https://api.cookiecloud.com/api_root', '/get/user_key')
'https://api.cookiecloud.com/get/user_key'

>>> urljoin('https://api.cookiecloud.com/api_root/', 'get/user_key')
'https://api.cookiecloud.com/api_root/get/user_key'

>>> urljoin('https://api.cookiecloud.com/api_root/', '/get/user_key')
'https://api.cookiecloud.com/get/user_key'
```

Obviously, there is only one way of get correct expectation.