### PR TITLE
Add apr_root support

### DIFF
--- a/PyCookieCloud/PyCookieCloud.py
+++ b/PyCookieCloud/PyCookieCloud.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 from typing import Optional, Dict, List, Any
 from urllib.parse import urljoin,urlparse
-from pathlib import Path
+from pathlib import PurePosixPath
 
 import requests
 
@@ -15,7 +15,7 @@ class PyCookieCloud:
         self.url: str = url
         self.uuid: str = uuid
         self.password: str = password
-        self.api_root: str = urlparse(url).path if urlparse(url).path else None
+        self.api_root: str = urlparse(url).path if urlparse(url).path else '/'
 
     def check_connection(self) -> bool:
         """
@@ -39,7 +39,7 @@ class PyCookieCloud:
         :return: The encrypted data if the connection is successful, None otherwise.
         """
         if self.check_connection():
-            path = str(Path(self.api_root, 'get/', self.uuid))
+            path = str(PurePosixPath(self.api_root, 'get/', self.uuid))
             cookie_cloud_request = requests.get(urljoin(self.url, path))
             if cookie_cloud_request.status_code == 200:
                 cookie_cloud_response = cookie_cloud_request.json()

--- a/PyCookieCloud/PyCookieCloud.py
+++ b/PyCookieCloud/PyCookieCloud.py
@@ -2,7 +2,8 @@ import collections
 import hashlib
 import json
 from typing import Optional, Dict, List, Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin,urlparse
+from pathlib import Path
 
 import requests
 
@@ -14,6 +15,7 @@ class PyCookieCloud:
         self.url: str = url
         self.uuid: str = uuid
         self.password: str = password
+        self.api_root: str = urlparse(url).path if urlparse(url).path else None
 
     def check_connection(self) -> bool:
         """
@@ -37,7 +39,8 @@ class PyCookieCloud:
         :return: The encrypted data if the connection is successful, None otherwise.
         """
         if self.check_connection():
-            cookie_cloud_request = requests.get(urljoin(self.url, 'get/' + self.uuid))
+            path = str(Path(self.api_root, 'get/', self.uuid))
+            cookie_cloud_request = requests.get(urljoin(self.url, path))
             if cookie_cloud_request.status_code == 200:
                 cookie_cloud_response = cookie_cloud_request.json()
                 encrypted_data = cookie_cloud_response["encrypted"]


### PR DESCRIPTION
CookieCloud supports the API_ROOT environment variable, which allows you to specify the interface path. After using it, I found that PyCookieCloud did not support this feature, so I added it.
CookieCloud 支持API_ROOT这个环境变量，可以指定接口路径。使用后发现 PyCookieCloud 不支持这个特性，于是加上去了。